### PR TITLE
Use binary sets rather than lists in coqdep loadpaths.

### DIFF
--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -84,16 +84,21 @@ let safe_assoc ?(warn_clashes=true) st ?(what=Library) from file k =
     | External -> Loadpath.search_other_known st in
   match search ?from k with
   | None -> None
-  | Some (Loadpath.ExactMatches (f :: l)) ->
+  | Some (Loadpath.ExactMatches fs) ->
+    let f = fs.Loadpath.point in
+    let l = Loadpath.FileSet.elements fs.files in
+    let l = List.map Loadpath.Filename.repr l in
+    let l = List.filter (fun f' -> not (String.equal f f')) l in
     if warn_clashes then warn_if_clash ~what true file k f l;
     Some [f]
   | Some (Loadpath.PartialMatchesInSameRoot (root, l)) ->
+    let l = Loadpath.FileSet.elements l.files in
+    let l = List.map Loadpath.Filename.repr l in
     (match List.sort String.compare l with [] -> assert false | f :: l as all ->
     (* If several files match, it will fail at Require;
        To be "fair", in rocq dep, we add dependencies on all matching files *)
     if warn_clashes then warn_if_clash ~what false file k f l;
     Some all)
-  | Some (Loadpath.ExactMatches []) -> assert false
 
 let file_name s = function
   | None     -> s

--- a/tools/coqdep/lib/loadpath.mli
+++ b/tools/coqdep/lib/loadpath.mli
@@ -19,9 +19,22 @@ type filename = string
 type dirpath = string list
 type root = filename * dirpath
 
+module Filename :
+sig
+  type t
+  val repr : t -> filename
+end
+
+module FileSet : Set.S with type elt = Filename.t
+
+type fileset = private {
+  point : filename;
+  files : FileSet.t; (* guaranteed to contain [point] *)
+}
+
 type result =
-  | ExactMatches of filename list
-  | PartialMatchesInSameRoot of root * filename list
+  | ExactMatches of fileset
+  | PartialMatchesInSameRoot of root * fileset
 
 module State : sig
   type t


### PR DESCRIPTION
The new behaviour should be extensionally the same, as we rely on the same canonization algorithm to identify filenames and compare them in the set. Yet this is algorithmically much faster.

Fixes #21022: rocqdep should be faster.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
